### PR TITLE
#62, #63, #64: fixes

### DIFF
--- a/src/generateZipandBlockmap.ts
+++ b/src/generateZipandBlockmap.ts
@@ -1,45 +1,59 @@
+import { getAppDistPath, getAppName, getArtifactName, getChannel } from "./utils";
+
 const path = require("path");
 const { execSync } = require("child_process");
 const fs = require("fs");
 const yaml = require("js-yaml");
 const { appBuilderPath } = require("app-builder-bin");
-const currentWorkingDirectory = process.cwd();
-const packageInfo = require(path.join(currentWorkingDirectory, "package.json"));
 
-const APP_NAME = packageInfo.build.productName;
-const APP_VERSION = process.argv[2] ? process.argv[2] : packageInfo.version;
-const CHANNEL = APP_VERSION.indexOf('beta') > -1 ? 'beta' : APP_VERSION.indexOf('alpha') > -1 ? 'alpha': 'latest';
-const APP_DIST_PATH = path.join(currentWorkingDirectory, "dist");
+function generateZipandBlockmap(buildConfPath: string | undefined = undefined) {
+  const appName = getAppName(buildConfPath);
+  const channel = getChannel(buildConfPath);
+  const appDistPath = getAppDistPath(buildConfPath);
+  const artifactName = getArtifactName('zip', buildConfPath);
+  const appPath = path.join(
+    `${appDistPath}`,
+    'mac',
+    `${appName}.app`
+  );
+  const appGeneratedBinPath = path.join(
+    appDistPath,
+    `${artifactName}`
+  );
 
-function generateZipandBlockmap() {
+  console.log("the appName = ", appName);
+  console.log("the channel = ", channel);
+  console.log("the appDistPath = ", appDistPath);
+  console.log("the artifactName = ", artifactName);
+  console.log("the appPath = ", appPath);
+  console.log("the appGeneratedBinPath = ", appGeneratedBinPath);
+
   console.log("Zipping...");
 
   execSync(
-    `ditto -V -c  -k --sequesterRsrc --keepParent "${APP_DIST_PATH}/mac/${APP_NAME}.app" "${APP_DIST_PATH}/${APP_NAME}-${APP_VERSION}-mac.zip"`
+    `ditto -V -c  -k --sequesterRsrc --keepParent "${appPath}" "${appGeneratedBinPath}"`
   );
 
   console.log("Zipping Completed");
 
-  const APP_GENERATED_BINARY_PATH = path.join(
-    APP_DIST_PATH,
-    `${APP_NAME}-${APP_VERSION}-mac.zip`
-  );
-
   try {
     let output = execSync(
-      `${appBuilderPath} blockmap --input="${APP_GENERATED_BINARY_PATH}" --output="${APP_DIST_PATH}/${APP_NAME}-${APP_VERSION}-mac.zip.blockmap" --compression=gzip`
+      `${appBuilderPath} blockmap --input="${appGeneratedBinPath}" --output="${appGeneratedBinPath}.blockmap" --compression=gzip`
     );
     let { sha512, size } = JSON.parse(output);
 
-    const ymlPath = path.join(APP_DIST_PATH, `${CHANNEL}-mac.yml`);
+    const ymlPath = path.join(appDistPath, `${channel}-mac.yml`);
     let ymlData = yaml.safeLoad(fs.readFileSync(ymlPath, "utf8"));
-    console.log(ymlData);
+    console.log(`Before SHA512 Update: ${channel}-mac.yml data \n`, ymlData);
+
     ymlData.sha512 = sha512;
     ymlData.files[0].sha512 = sha512;
     ymlData.files[0].size = size;
+
     let yamlStr = yaml.safeDump(ymlData);
-    console.log(yamlStr);
     fs.writeFileSync(ymlPath, yamlStr, "utf8");
+    console.log(`After SHA512 Update: ${channel}-mac.yml data \n${yamlStr}\n`);
+
     console.log(
       "Successfully updated YAML file and configurations with blockmap."
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,150 @@
+const path = require("path");
+const fs = require("fs");
+const yaml = require("js-yaml");
+const currentWorkingDirectory = process.cwd();
+const packageInfo = require(path.join(currentWorkingDirectory, "package.json"));
+
+const CONFIG_EXTS = ['yml', 'json'];
+
+
+let _BUILD_CONFIGURATION: any | undefined = undefined;
+
+export function getBuildConfiguration(confPath: string | undefined = undefined) {
+    function _getConf(cPath: string | undefined) {
+        if (!cPath) {
+            const iConfPath = path.join(
+                currentWorkingDirectory,
+                'electron-builder'
+            );
+            for (let ext of CONFIG_EXTS) {
+                if (fs.existsSync(iConfPath + '.' + ext)) {
+                    cPath = iConfPath + '.' + ext;
+                    break;
+                }
+            }
+        }
+
+        if (!cPath) {
+            return packageInfo.build || {}
+        }
+
+        if (cPath.endsWith('.yml')) {
+            return yaml.safeLoad(fs.readFileSync(cPath, {encoding: "utf-8"}));
+        } else {
+            return JSON.parse(fs.readFileSync(cPath, {encoding: "utf-8"}));
+        }
+    }
+
+    if (_BUILD_CONFIGURATION === undefined) {
+        _BUILD_CONFIGURATION = _getConf(confPath);
+    }
+
+    return _BUILD_CONFIGURATION;
+}
+
+export function getAppName(confPath: string | undefined = undefined) {
+    const build_conf = getBuildConfiguration(confPath);
+
+    return build_conf?.productName || packageInfo.name
+}
+
+export function getAppVersion(confPath: string | undefined = undefined) {
+    const build_conf = getBuildConfiguration(confPath);
+
+    return build_conf?.buildVersion || (process.argv[2] ? process.argv[2] : packageInfo.version)
+}
+
+export function getChannel(confPath: string | undefined = undefined) {
+    const build_conf = getBuildConfiguration(confPath);
+
+    let defaultChannel = 'latest'; // default;
+    let channel = defaultChannel;
+
+    let confChannel: string | undefined = build_conf?.publish?.channel;
+
+    if (!confChannel) {
+        const appVersion = getAppVersion(confPath);
+
+        const versionSplit = appVersion.split('-');
+        if (versionSplit.length > 1) {
+            channel = versionSplit[1]
+        }
+    } else {
+        channel = confChannel;
+    }
+
+    return channel;
+}
+
+export function getAppDistPath(confPath: string | undefined = undefined) {
+    const build_conf = getBuildConfiguration(confPath);
+
+    let outDir = build_conf?.directories?.output || "dist";
+
+    if (outDir.endsWith('/')) {
+        outDir = outDir.slice(0, outDir.length - 1);
+    }
+
+    return path.join(currentWorkingDirectory, outDir)
+}
+
+export function getFileMacros(confPath: string | undefined = undefined) {
+    const build_conf = getBuildConfiguration(confPath);
+
+    const productName = getAppName(confPath);
+    const version = getAppVersion(confPath);
+    const channel = getChannel(confPath);
+
+    const platform = process.platform;
+    const isMac = (platform === 'darwin');
+    const isWin = (platform === 'win32');
+
+    let retData: {[id: string]: string} = {
+        "${arch}": process.arch,
+        "${os}": isMac? 'mac' : (isWin? 'win' : 'linux'),
+        "${platform}": platform,
+        "${name}": packageInfo.name,
+        "${productName}": productName,
+        "${version}": version,
+        "${channel}": channel,
+        "${description}": packageInfo.description || '',
+        "${id}": build_conf.appId,
+        "${copyright}": build_conf.copyright,
+    }
+
+    for (const [k, v] of Object.entries(process.env)) {
+        retData["$env." + k] = v as string;
+    }
+
+    return retData;
+}
+
+export function replaceAll(inStr: string, k: string, v: string) {
+    let outStr = inStr;
+    let nOutStr = outStr.replace(k, v);
+    while (nOutStr !== outStr) {  // mimic replaceAll.
+        outStr = nOutStr;
+        nOutStr = outStr.replace(k, v);
+    }
+
+    return outStr;
+}
+
+export function transformMacros(inStr: string, confPath: string | undefined = undefined) {
+    const macros = getFileMacros(confPath);
+    let outStr = inStr;
+    for (const [k, v] of Object.entries(macros)) {
+        outStr = replaceAll(outStr, k, v);
+    }
+
+    return outStr
+}
+
+export function getArtifactName(ext = 'zip', confPath: string | undefined = undefined) {
+    const build_conf = getBuildConfiguration(confPath);
+    let artifactName = build_conf?.artifactName || "${productName}-${version}.${ext}";
+
+    artifactName = transformMacros(artifactName, confPath);
+
+    return replaceAll(artifactName, "${ext}", ext);
+}


### PR DESCRIPTION
`generateZipandBlockmap` now takes in an optional path to the config file defaults to `pwd/electron-builder.{json | yml}`.

** Added additional utility functions.
1. getBuildConfiguration: get the build configuration from the config path or from `package.json` --> `build`.
2. getAppName: get app name from build configuration defaults to `package.json` --> `name`
3. getAppVersion: get app version from build configuration defaults to `process.argv[2]` if exists else `package.json` --> `version`
4. getChannel: get channel from build configuration defaults to `package.json` --> `version`'s channel part if exists else `latest`
5. getAppDistPath: get output path from build configuration defaults to 'dist'
6. getFileMacros: get file macros to substitute in `artifactName`
7. getArtifactName: get `artifactName` after substituting in `artifactName` template from build configuration. default template is "`${productName}-${version}.${ext}`"
8. transformMacros: to transform and template with the available macros from config.

